### PR TITLE
ビューファイルの部分テンプレートの実装

### DIFF
--- a/app/views/tweets/_form.html.erb
+++ b/app/views/tweets/_form.html.erb
@@ -1,0 +1,13 @@
+    <%# 部分テンプレートでフォーム部分を扱う %>
+    <%# ヘルパーメソッドform_withのmodelオプションにnewアクションで生成したインスタンスを指定している。
+    modelオプションは指定したインスタンスが空ならcreateアクション、値が入っていればupdateアクションに自動的に振り分ける。
+    またurlやmethodの記述が不要になる。local:trueは必要 %>
+    <%= form_with(model: tweet, local: true) do |form| %>
+    <%# 部分テンプレートにしたのでmodelオプションの引数を@tweetからtweetに変更。呼び出し元をlocals: {tweet: @tweet}としている %>
+      <%# ツイートにユーザー名が表示されるように変更したので投稿時のニックネーム欄は不要。 %>
+      <%= form.text_field :image, placeholder: "Image Url" %>
+      <%= form.text_area :text, placeholder: "text", rows: "10" %>
+      <%# form.フォーム部品の種類 :パラメーターとして渡すname属性の値(シンボル)(キー名) :プレースホルダーオプション: "見本の文字列", rows: "文字数制限"%>
+      <%= form.submit "SEND" %>
+      <%# form.submit "ボタンに表示される文字列" %>
+    <% end %>

--- a/app/views/tweets/_tweet.html.erb
+++ b/app/views/tweets/_tweet.html.erb
@@ -1,0 +1,29 @@
+    <%# 投稿一覧を部分テンプレートに記述 %>
+    <div class="content_post" style="background-image: url(<%= tweet.image %>);">
+    <%# 1つのレコードはcontent_postクラスのdivに囲まれており、背景画像に投稿した画像を指定している。%>
+      <div class="more">
+        <span><%= image_tag 'arrow_top.png' %></span>
+        <%# image_tag 'ファイル名' app/assets/images/ディレクトリの矢印の画像を追加。 %>
+        <ul class="more_list">
+          <li><%= link_to '詳細', tweet_path(tweet.id), method: :get %></li>
+          <% if user_signed_in? && current_user.id == tweet.user_id %>
+          <%# 「ユーザーがサインイン状態かつ、ツイートが自分の投稿であれば」編集と削除ボタンを表示させている。
+          条件に当てはまらなくても詳細ボタンは表示される。if文の外側なので。 %>
+            <li><%= link_to '編集', edit_tweet_path(tweet.id), method: :get %></li>
+            <%# 編集するツイートを区別するためにブロック変数tweetのidをパラメーターに持たせる %>
+            <li><%= link_to '削除', tweet_path(tweet.id), method: :delete %></li>
+            <%# link_to '表示される文字列', 遷移先のパス(URLorPrefix)削除するツイートを区別するためにブロック変数tweetのidをパラメーターに持たせる, :get以外はmethod:の記述が必要 %>
+          <% end %>
+        </ul>
+      </div>
+      <p><%= tweet.text %></p>
+      <%# 投稿したテキストを表示している %>
+      <span class="name">
+        <a href="/users/<%= tweet.user.id %>" > <%# ツイートを投稿したユーザーのshowアクションへのパスは "/users/ツイートしたユーザーのidの値" %>
+          <span>投稿者</span><%= tweet.user.nickname %>
+        </a>
+        <%# Tweetモデルはアソシエーションにより、一人のユーザーに属しているため、
+        Tweetモデルのインスタンスが入った変数.user と記述することで属しているユーザーモデルのインスタンスを取得できる。
+        それを利用して投稿したユーザー名を表示している。 %>
+      </span>
+    </div>

--- a/app/views/tweets/edit.html.erb
+++ b/app/views/tweets/edit.html.erb
@@ -2,12 +2,7 @@
 <div class="contents row">
   <div class="container">
     <h3>編集する</h3>
-    <%= form_with(model: @tweet, local: true) do |form| %>
-    <%# editアクションの@tweetには値が入っているためmodelオプションではupdateアクション宛にデータを送る。 %>
-      <%# ツイートにユーザー名が表示されるように変更したので編集時のニックネーム欄は不要。 %>
-      <%= form.text_field :image, placeholder: "Image Url" %>
-      <%= form.text_area :text, placeholder: "text", rows: "10" %>
-      <%= form.submit "SEND" %>
-    <% end %>
+      <%= render partial: "form", locals: {tweet: @tweet} %>
+      <%# フォーム部分を部分テンプレートに記述 %>
   </div>
 </div>

--- a/app/views/tweets/index.html.erb
+++ b/app/views/tweets/index.html.erb
@@ -1,34 +1,17 @@
 <%# contentsクラスのdivの中に@tweetsで取得した全てのレコードを表示している %>
 <div class="contents row">
-  <% @tweets.each do |tweet| %>
+  <%# <% @tweets.each do |tweet| %>
   <%# @tweetsで取得したレコード1つ1つをeach文で取り出して、ブロック変数tweetに入れている %>
-    <div class="content_post" style="background-image: url(<%= tweet.image %>);">
-    <%# 1つのレコードはcontent_postクラスのdivに囲まれており、背景画像に投稿した画像を指定している。%>
-      <div class="more">
-        <span><%= image_tag 'arrow_top.png' %></span>
-        <%# image_tag 'ファイル名' app/assets/images/ディレクトリの矢印の画像を追加。 %>
-        <ul class="more_list">
-          <li><%= link_to '詳細', tweet_path(tweet.id), method: :get %></li>
-          <% if user_signed_in? && current_user.id == tweet.user_id %>
-          <%# 「ユーザーがサインイン状態かつ、ツイートが自分の投稿であれば」編集と削除ボタンを表示させている。
-          条件に当てはまらなくても詳細ボタンは表示される。if文の外側なので。 %>
-            <li><%= link_to '編集', edit_tweet_path(tweet.id), method: :get %></li>
-            <%# 編集するツイートを区別するためにブロック変数tweetのidをパラメーターに持たせる %>
-            <li><%= link_to '削除', tweet_path(tweet.id), method: :delete %></li>
-            <%# link_to '表示される文字列', 遷移先のパス(URLorPrefix)削除するツイートを区別するためにブロック変数tweetのidをパラメーターに持たせる, :get以外はmethod:の記述が必要 %>
-          <% end %>
-        </ul>
-      </div>
-      <p><%= tweet.text %></p>
-      <%# 投稿したテキストを表示している %>
-      <span class="name">
-        <a href="/users/<%= tweet.user.id %>" > <%# ツイートを投稿したユーザーのshowアクションへのパスは "/users/ツイートしたユーザーのidの値" %>
-          <span>投稿者</span><%= tweet.user.nickname %>
-        </a>
-        <%# Tweetモデルはアソシエーションにより、一人のユーザーに属しているため、
-        Tweetモデルのインスタンスが入った変数.user と記述することで属しているユーザーモデルのインスタンスを取得できる。
-        それを利用して投稿したユーザー名を表示している。 %>
-      </span>
-    </div>
-  <% end  %>
+    <%# render pattial: "部分テンプレート名", locals: {部分テンプレートで使用したい変数名: 渡したい変数に入っているもの(ブロック変数tweetの値)} %>
+    
+    <%= render @tweets %>
+    <%# render partial: "部分テンプレート名(部分テンプレート内で使用する変数名にもなる)", collection: @複数のデータが入っているインスタンス変数名
+    上記のように記述すると、指定したインスタンス変数の中にある要素の数だけ部分テンプレートが繰り返し表示される。 
+    また、以下3つの条件が揃うと、  render @tweets で記述できる。
+    ・呼び出す部分テンプレートがviewsフォルダ内にあるtweetsフォルダにある。
+    ・部分テンプレート名が_tweet.html.erbである
+    ・部分テンプレート内で使う変数がtweetである
+    %>
+
+  <%# <% end  %>
 </div>

--- a/app/views/tweets/new.html.erb
+++ b/app/views/tweets/new.html.erb
@@ -2,16 +2,7 @@
   <div class="container">
   <%# 投稿ページをcontainerクラスのdivで囲う %>
     <h3>投稿する</h3>
-    <%# ヘルパーメソッドform_withのmodelオプションにnewアクションで生成したインスタンスを指定している。
-    modelオプションは指定したインスタンスが空ならcreateアクション、値が入っていればeditアクションに自動的に振り分ける。
-    またurlやmethodの記述が不要になる。local:trueは必要 %>
-    <%= form_with(model: @tweet, local: true) do |form| %>
-      <%# ツイートにユーザー名が表示されるように変更したので投稿時のニックネーム欄は不要。 %>
-      <%= form.text_field :image, placeholder: "Image Url" %>
-      <%= form.text_area :text, placeholder: "text", rows: "10" %>
-      <%# form.フォーム部品の種類 :パラメーターとして渡すname属性の値(シンボル)(キー名) :プレースホルダーオプション: "見本の文字列", rows: "文字数制限"%>
-      <%= form.submit "SEND" %>
-      <%# form.submit "ボタンに表示される文字列" %>
-    <% end %>
+      <%= render partial: "form", locals: {tweet: @tweet} %>
+      <%# form部分を部分テンプレートに記述 %>
   </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,9 +1,4 @@
 <div class="contents row">
   <p><%= @nickname %>さんの投稿一覧</p>
-  <% @tweets.each do |tweet| %>
-    <div class="content_post" style="background-image: url(<%= tweet.image %>);">
-      <p><%= tweet.text %></p>
-      <%# 投稿者のマイページなのでツイートの投稿者名は不要。 %>
-    </div>
-  <% end %>
+    <%= render @tweets %>
 </div>


### PR DESCRIPTION
# What
- indexとユーザーページのツイート一覧表示を部分テンプレートに記述
- 投稿と編集のフォーム表示を部分テンプレートに記述

# Why
共通部分を部分テンプレートにすることで記述を短くし、保守性を向上させるため